### PR TITLE
fix: Disable qtglspectrum on aarch64

### DIFF
--- a/org.atheme.audacious.yaml
+++ b/org.atheme.audacious.yaml
@@ -55,6 +55,12 @@ modules:
 
   - name: audacious-plugins
     buildsystem: meson
+    build-options:
+      arch:
+        aarch64:
+          config-opts:
+            - -Dgl-spectrum=false
+
     # config-opts:
     #  - -D=adplug=false
     #  - -D=cdaudio=false


### PR DESCRIPTION
```c
FAILED: src/qtglspectrum/gl-spectrum-qt.so.p/gl-spectrum.cc.o 
ccache c++ -Isrc/qtglspectrum/gl-spectrum-qt.so.p -Isrc/qtglspectrum -I../src/qtglspectrum -I/usr/include/QtCore -I/usr/include/QtWidgets -I/usr/include/QtGui -I/usr/include/QtOpenGL -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=gnu++11 -g -ffast-math -Wtype-limits -Wno-stringop-truncation -fvisibility=hidden -Wno-non-virtual-dtor -Woverloaded-virtual -DHAVE_GETTEXT -include /run/build/audacious-plugins/_flatpak_build/src/config.h -O2 -g -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection -fPIC -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB -MD -MQ src/qtglspectrum/gl-spectrum-qt.so.p/gl-spectrum.cc.o -MF src/qtglspectrum/gl-spectrum-qt.so.p/gl-spectrum.cc.o.d -o src/qtglspectrum/gl-spectrum-qt.so.p/gl-spectrum.cc.o -c ../src/qtglspectrum/gl-spectrum.cc
../src/qtglspectrum/gl-spectrum.cc:80:1: error: expected class-name before ‘{’ token
   80 | {
      | ^
../src/qtglspectrum/gl-spectrum.cc: In member function ‘void GLSpectrumWidget::draw_rectangle(float, float, float, float, float, float, float, float, float)’:
../src/qtglspectrum/gl-spectrum.cc:182:5: error: ‘glColor4f’ was not declared in this scope; did you mean ‘glColorMask’?
  182 |     glColor4f (r, g, b, 1.0f);
      |     ^~~~~~~~~
      |     glColorMask
../src/qtglspectrum/gl-spectrum.cc:184:14: error: ‘GL_POLYGON’ was not declared in this scope; did you mean ‘GL_COLOR’?
  184 |     glBegin (GL_POLYGON);
      |              ^~~~~~~~~~
      |              GL_COLOR
../src/qtglspectrum/gl-spectrum.cc:184:5: error: ‘glBegin’ was not declared in this scope
  184 |     glBegin (GL_POLYGON);
      |     ^~~~~~~
../src/qtglspectrum/gl-spectrum.cc:185:5: error: ‘glVertex3f’ was not declared in this scope
  185 |     glVertex3f (x1, y2, z1);
      |     ^~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:189:5: error: ‘glEnd’ was not declared in this scope
  189 |     glEnd ();
      |     ^~~~~
../src/qtglspectrum/gl-spectrum.cc: In member function ‘void GLSpectrumWidget::draw_bars()’:
../src/qtglspectrum/gl-spectrum.cc:225:5: error: ‘glPushMatrix’ was not declared in this scope
  225 |     glPushMatrix ();
      |     ^~~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:226:5: error: ‘glTranslatef’ was not declared in this scope
  226 |     glTranslatef (0.0f, -0.5f, -5.0f);
      |     ^~~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:227:5: error: ‘glRotatef’ was not declared in this scope
  227 |     glRotatef (38.0f, 1.0f, 0.0f, 0.0f);
      |     ^~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:229:39: error: ‘GL_FILL’ was not declared in this scope
  229 |     glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
      |                                       ^~~~~~~
../src/qtglspectrum/gl-spectrum.cc:229:5: error: ‘glPolygonMode’ was not declared in this scope; did you mean ‘glPolygonOffset’?
  229 |     glPolygonMode (GL_FRONT_AND_BACK, GL_FILL);
      |     ^~~~~~~~~~~~~
      |     glPolygonOffset
../src/qtglspectrum/gl-spectrum.cc:244:5: error: ‘glPopMatrix’ was not declared in this scope
  244 |     glPopMatrix ();
      |     ^~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc: In member function ‘virtual void GLSpectrumWidget::paintGL()’:
../src/qtglspectrum/gl-spectrum.cc:263:19: error: ‘GL_PROJECTION’ was not declared in this scope; did you mean ‘GL_LOCATION’?
  263 |     glMatrixMode (GL_PROJECTION);
      |                   ^~~~~~~~~~~~~
      |                   GL_LOCATION
../src/qtglspectrum/gl-spectrum.cc:263:5: error: ‘glMatrixMode’ was not declared in this scope
  263 |     glMatrixMode (GL_PROJECTION);
      |     ^~~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:264:5: error: ‘glPushMatrix’ was not declared in this scope
  264 |     glPushMatrix();
      |     ^~~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:265:5: error: ‘glLoadIdentity’ was not declared in this scope
  265 |     glLoadIdentity();
      |     ^~~~~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:266:5: error: ‘glFrustum’ was not declared in this scope
  266 |     glFrustum (-1.1f, 1, -1.5f, 1, 2, 10);
      |     ^~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:267:19: error: ‘GL_MODELVIEW’ was not declared in this scope
  267 |     glMatrixMode (GL_MODELVIEW);
      |                   ^~~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc:272:30: error: ‘GL_FILL’ was not declared in this scope
  272 |     glPolygonMode (GL_FRONT, GL_FILL);
      |                              ^~~~~~~
../src/qtglspectrum/gl-spectrum.cc:272:5: error: ‘glPolygonMode’ was not declared in this scope; did you mean ‘glPolygonOffset’?
  272 |     glPolygonMode (GL_FRONT, GL_FILL);
      |     ^~~~~~~~~~~~~
      |     glPolygonOffset
../src/qtglspectrum/gl-spectrum.cc:281:5: error: ‘glPopMatrix’ was not declared in this scope
  281 |     glPopMatrix ();
      |     ^~~~~~~~~~~
../src/qtglspectrum/gl-spectrum.cc: In member function ‘virtual void GLSpectrumWidget::initializeGL()’:
../src/qtglspectrum/gl-spectrum.cc:295:5: error: ‘initializeOpenGLFunctions’ was not declared in this scope
  295 |     initializeOpenGLFunctions ();
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
```