### PR TITLE
Fix status icon not appearing on KDE Plasma.

### DIFF
--- a/org.atheme.audacious.yaml
+++ b/org.atheme.audacious.yaml
@@ -26,6 +26,7 @@ finish-args:
   - --socket=wayland
   - --socket=x11
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
 rename-desktop-file: audacious.desktop
 rename-icon: audacious
 cleanup:


### PR DESCRIPTION
Allow talking to org.kde.StatusNotifierWatcher

Fixes status icon not appearing on KDE Plasma.