### PR TITLE
Allow talking to org.kde.StatusNotifierWatcher

### DIFF
--- a/org.atheme.audacious.yaml
+++ b/org.atheme.audacious.yaml
@@ -26,6 +26,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
 rename-desktop-file: audacious.desktop
 rename-icon: audacious
 cleanup:


### PR DESCRIPTION
Fixes status icon not appearing on KDE Plasma.

fix: #31 #40

@iamalexei please test this change.