### PR TITLE
Update KDE runtime to 6.8, update components

### DIFF
--- a/org.atheme.audacious.yaml
+++ b/org.atheme.audacious.yaml
@@ -1,6 +1,6 @@
 id: org.atheme.audacious
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
@@ -8,7 +8,7 @@ add-extensions:
     autodelete: false
     autodownload: true
     directory: lib/ffmpeg
-    version: '23.08'
+    version: '24.08'
 cleanup-commands:
   - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 command: audacious
@@ -90,16 +90,6 @@ modules:
           tag-pattern: ^(audacious-plugins-[\d.]+)$
 
     modules:
-      - name: libnotify
-        buildsystem: meson
-        config-opts:
-          - -D=man=false
-          - -D=gtk_doc=false
-        sources:
-          - type: archive
-            url: https://ftp.acc.umu.se/pub/GNOME/sources/libnotify/0.7/libnotify-0.7.9.tar.xz
-            sha256: 66c0517ed16df7af258e83208faaf5069727dfd66995c4bbc51c16954d674761
-
       - name: neon
         config-opts:
           - --disable-static
@@ -107,8 +97,8 @@ modules:
         sources:
           - type: git
             url: https://github.com/notroj/neon.git
-            tag: 0.32.1
-            commit: 0a02e288f501d65be6746cfb023f0ee8ff9869fb
+            tag: 0.34.0
+            commit: ea26872a0e2b684c93e715194ca02c8ff90b40ca
             # x-checker-data:
             #   type: git
             #   url: https://github.com/notroj/neon.git
@@ -150,6 +140,8 @@ modules:
           - type: shell
             commands:
               - cp -p /usr/share/automake-*/config.{sub,guess} .
+          - type: patch
+            path: patches/libcddb:pointer-types.patch
 
       - shared-modules/linux-audio/fluidsynth2.json
 
@@ -158,8 +150,12 @@ modules:
           - --disable-static
         sources:
           - type: archive
-            url: https://downloads.sourceforge.net/project/sidplay-residfp/libsidplayfp/2.3/libsidplayfp-2.3.1.tar.gz
-            sha256: aef70cc30648eb89d32f56c691a5a40cdffc7421f43b4aa242f4d123eb9258a2
+            url: https://github.com/libsidplayfp/libsidplayfp/releases/download/v2.12.0/libsidplayfp-2.12.0.tar.gz
+            sha256: bc4f4fa203dcf0736fe48c23dce9aa0db825370e5941e7595e4851efe6937cdc
+            x-checker-data:
+              type: anitya
+              id: 1721
+              url-template: https://github.com/libsidplayfp/libsidplayfp/releases/download/v$version/libsidplayfp-$version.tar.gz
 
       - name: modplug
         config-opts:
@@ -176,17 +172,31 @@ modules:
           - --without-portaudiocpp
         sources:
           - type: archive
-            url: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.6.6+release.autotools.tar.gz
-            sha256: 6ddb9e26a430620944891796fefb1bbb38bd9148f6cfc558810c0d3f269876c7
+            url: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.7.13+release.autotools.tar.gz
+            sha256: dcd7cde4f9c498eb496c4556e1c1b81353e2a74747e8270a42565117ea42e1f1
+            x-checker-data:
+              type: anitya
+              project-id: 141468
+              url-template: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-$version+release.autotools.tar.gz
 
       - name: cdio
         config-opts:
           - --disable-static
+          - --without-cd-drive
+          - --without-cd-info
           - --without-cdda-player
+          - --without-cd-read
+          - --without-iso-info
+          - --without-iso-read
+          - --with-pic
         sources:
-          - type: archive
-            url: https://ftp.gnu.org/gnu/libcdio/libcdio-2.1.0.tar.bz2
-            sha256: 8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b
+          - type: git
+            url: https://github.com/libcdio/libcdio.git
+            tag: 2.2.0
+            commit: 3922b045fa3dfa7c8e062641ac619a344e23c0a9
+            x-checker-data:
+              type: git
+              tag-pattern: ([\d.]+)
 
       - name: cdio-paranoia
         config-opts:

--- a/patches/libcddb:pointer-types.patch
+++ b/patches/libcddb:pointer-types.patch
@@ -1,0 +1,16 @@
+---
+ lib/cddb_net.c |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/lib/cddb_net.c
++++ b/lib/cddb_net.c
+@@ -325,7 +325,7 @@ int timeout_connect(int sockfd, const st
+             default:
+                 /* we got connected, check error condition */
+                 l = sizeof(rv);
+-                getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &rv, &l);
++                getsockopt(sockfd, SOL_SOCKET, SO_ERROR, &rv, (socklen_t * restrict)&l);
+                 if (rv) {
+                     /* something went wrong, simulate normal connect behaviour */
+                     errno = rv;
+

--- a/patches/neon:remove-hardcoded-install-paths.patch
+++ b/patches/neon:remove-hardcoded-install-paths.patch
@@ -1,18 +1,20 @@
---- a/Makefile.in	2021-09-20 22:17:44.000000000 +0300
-+++ b/Makefile.in	2021-10-01 00:46:29.361325664 +0300
-@@ -126,22 +126,6 @@
+diff --git a/Makefile.in b/Makefile.in
+index d6787c5..13caa4b 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -126,22 +126,6 @@ Makefile: $(srcdir)/Makefile.in
  neon-config: $(srcdir)/neon-config.in
  	@./config.status neon-config
  
 -install-docs: install-man install-html
 -
--install-html: docs-html
+-install-html:
 -	$(INSTALL) -d $(DESTDIR)$(docdir)/html
 -	for d in doc/html/*.html; do \
 -		$(INSTALL_DATA) $$d $(DESTDIR)$(docdir)/html; \
 -	done
 -
--install-man: docs-man
+-install-man:
 -	$(INSTALL) -d $(DESTDIR)$(man3dir)
 -	$(INSTALL) -d $(DESTDIR)$(man1dir)
 -	for m in doc/man/*.3; do \
@@ -23,7 +25,7 @@
  install: install-@ALLOW_INSTALL@
  
  install-memleak:
-@@ -149,7 +133,7 @@
+@@ -149,7 +133,7 @@ install-memleak:
  	@echo "ERROR: purposes only; this copy of neon must not be installed."
  	@false
  
@@ -32,7 +34,7 @@
  
  # libtool does all the necessary magic here
  install-lib: subdirs
-@@ -182,10 +166,6 @@
+@@ -182,10 +166,7 @@ install-nls-no:
  	@echo NLS not enabled.
  
  install-nls-yes:
@@ -40,6 +42,7 @@
 -	 $(INSTALL) -d $(DESTDIR)$(localedir)/$$f/LC_MESSAGES; \
 -	 $(INSTALL_DATA) $(srcdir)/po/$$f.gmo $(DESTDIR)$(localedir)/$$f/LC_MESSAGES/neon.mo; \
 -	done
++
  
  ChangeLog:
  	svn log > $@


### PR DESCRIPTION
Also added some x-checker-data for components where development is happening in a new place.

Took the config-flags for libcdio from Strawberry, but they are widely used for flatpaks and presumably fix some permission problems. Playing/ripping CDs work fine.

libnotify is part of the freedeskop runtime now