### PR TITLE
fix album covers not displaying in MPRIS

### DIFF
--- a/org.atheme.audacious.yaml
+++ b/org.atheme.audacious.yaml
@@ -19,6 +19,7 @@ finish-args:
   - --filesystem=xdg-download
   - --filesystem=xdg-music
   - --filesystem=xdg-run/pipewire-0
+  - --filesystem=/tmp
   - --own-name=org.mpris.MediaPlayer2.audacious
   - --share=ipc
   - --share=network

--- a/org.atheme.audacious.yaml
+++ b/org.atheme.audacious.yaml
@@ -10,8 +10,7 @@ finish-args:
   - --filesystem=xdg-download
   - --filesystem=xdg-music
   - --filesystem=xdg-run/pipewire-0
-  # Required to put album covers into /tmp for MPRIS to pick them up
-  - --filesystem=/tmp
+  - --filesystem=/tmp # Required to put album covers into /tmp for MPRIS to pick them up
   - --own-name=org.mpris.MediaPlayer2.audacious
   - --share=ipc
   - --share=network

--- a/org.atheme.audacious.yaml
+++ b/org.atheme.audacious.yaml
@@ -19,6 +19,7 @@ finish-args:
   - --filesystem=xdg-download
   - --filesystem=xdg-music
   - --filesystem=xdg-run/pipewire-0
+  # Required to put album covers into /tmp for MPRIS to pick them up
   - --filesystem=/tmp
   - --own-name=org.mpris.MediaPlayer2.audacious
   - --share=ipc


### PR DESCRIPTION
fixes #61  

by allowing audacious to write in /imp, it can create album cover files again, and MPRIS can find them
i have tested this by adding the permission in FlatSeal, but not by re-building the flatpak package from the new yaml.